### PR TITLE
Install local sources from the uv cache before hitting the index

### DIFF
--- a/ARC3-Inference/Makefile
+++ b/ARC3-Inference/Makefile
@@ -243,9 +243,15 @@ install-local-sources:
 		exit 1; \
 	fi
 	@if [ -d "$(REPO_ROOT)/../tufa-arc-agi-framework" ]; then \
-		$(UV) pip install --python "$(REPO_ROOT)/.venv/bin/python" \
+		if ! $(UV) pip install --offline --python "$(REPO_ROOT)/.venv/bin/python" \
 			--no-deps \
-			-e "$(REPO_ROOT)/../tufa-arc-agi-framework"; \
+			-e "$(REPO_ROOT)/../tufa-arc-agi-framework"; then \
+			echo "Offline editable install failed; retrying against the package index."; \
+			echo "This needs a host with internet; coe-hpc3 and the compute nodes have none."; \
+			$(UV) pip install --python "$(REPO_ROOT)/.venv/bin/python" \
+				--no-deps \
+				-e "$(REPO_ROOT)/../tufa-arc-agi-framework"; \
+		fi; \
 	fi
 
 prepare-ci:


### PR DESCRIPTION
## Problem

`install-local-sources` runs `uv pip install --no-deps -e ../tufa-arc-agi-framework`. The framework declares `build-system.requires = ["setuptools"]`, and uv honors build isolation, so it resolves that build requirement against `https://pypi.org/simple/setuptools/` — **even when the setuptools wheel is already in the uv cache**.

`--no-deps` does not prevent this; it only skips *runtime* dependencies.

On hosts without internet access (our `coe-hpc3` login node and all compute nodes), this retries three times, times out after ~50s, and fails:

```
× Failed to build `tufa-arc-agi-framework @ file:///.../tufa-arc-agi-framework`
├─▶ Failed to resolve requirements from `build-system.requires`
├─▶ No solution found when resolving: `setuptools`
├─▶ Failed to fetch: `https://pypi.org/simple/setuptools/`
╰─▶ operation timed out
make: *** [Makefile:288: install-local-sources] Error 1
```

Any target depending on `install-local-sources` dies with it before doing real work.

## Fix

Try the editable install with `--offline` first, falling back to the index only when the cache cannot satisfy the build. uv then resolves setuptools from its cache and the build succeeds in ~5s. The fallback keeps first-time installs on an internet-connected host working unchanged.

## Verification

Simulated an offline host by pointing `http_proxy`/`https_proxy` at a dead port:

- **Before:** reproduces the failure above (`Failed to fetch: https://pypi.org/simple/setuptools/`), exit 2.
- **After:** `Built tufa-arc-agi-framework` / `Installed 1 package` in ~5s, exit 0.

Also confirmed with the network available that the target still behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)